### PR TITLE
Upgrade to manifest v2, v1 is deprecated in Chrome 18

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,5 +8,6 @@
 	"permissions": [
 		"tabs",
 		"contextMenus" 
-	]
+	],
+	"manifest_version": 2
 }


### PR DESCRIPTION
> There were warnings when trying to install this extension:
> Support for manifest version 1 is being phased out. Please upgrade to version 2.

Fixes problem with manifest upgrade

http://developer.chrome.com/extensions/manifestVersion.html
