### PR TITLE
Resizable editors

### DIFF
--- a/src/coffee-console-app.js
+++ b/src/coffee-console-app.js
@@ -1,19 +1,84 @@
 var tabId = chrome.devtools.inspectedWindow.tabId;
+var resultsPanel = document.getElementById('cc-results');
+var editorPanel = document.getElementById('cc-editor');
 var err = document.getElementById('error');
 var editor = ace.edit("cc-editor");
-editor.setTheme("ace/theme/twilight");
-editor.session.setMode("ace/mode/coffee");
-editor.session.setUseSoftTabs(true);
-editor.session.setTabSize(2);
-editor.setShowPrintMargin(false);
-
 var compiled = ace.edit("cc-results");
-compiled.setTheme("ace/theme/twilight");
-compiled.session.setMode("ace/mode/javascript");
-compiled.session.setUseSoftTabs(true);
-compiled.session.setTabSize(2);
-compiled.setShowPrintMargin(false);
+var editorSizeKey = "cc-size";
+var gutter = resultsPanel.querySelector('.ace_gutter');
 
+function debug() {
+    var args = Array.prototype.slice.call(arguments);
+    var message = args.map(function(arg) {
+        return JSON.stringify(arg);
+    }).join(",")
+    chrome.devtools.inspectedWindow.eval("console.log(" + message + ")")
+}
+
+function debugClick() {
+  var offset = resultsPanel.offsetLeft;
+  var to = event.pageX;
+  var gutterWidth = gutter.offsetWidth
+  debug("click:", "to", to, "offset", offset, "gutter width", gutterWidth)
+}
+
+// use percentages in case window size changes
+function editorWidths() {
+    var windowWidth = window.innerWidth;
+    function percentWindow(width) {
+        return parseInt(width) / windowWidth * 100 + '%';
+    }
+    return {
+        editor: percentWindow(window.getComputedStyle(editorPanel).right),
+        results: percentWindow(window.getComputedStyle(resultsPanel).left)
+    }
+}
+
+function getSizes() {
+    var stored = localStorage.getItem(editorSizeKey);
+    var sizes;
+    if (stored) {
+        try {
+            sizes = JSON.parse(stored);
+        } catch(e) {
+            debug(e.message)
+            sizes = editorWidths();
+        }
+    } else {
+        sizes = editorWidths();
+    }
+    return sizes;
+}
+
+function setSizes(sizes) {
+    if (sizes.editor && sizes.results) {
+        editorPanel.style.right = sizes.editor;
+        resultsPanel.style.left = sizes.results;
+        localStorage.setItem(editorSizeKey, JSON.stringify(sizes));
+    }
+}
+
+function updatePanels() {
+    editor.setTheme("ace/theme/twilight");
+    editor.session.setMode("ace/mode/coffee");
+    editor.session.setUseSoftTabs(true);
+    editor.session.setTabSize(2);
+    editor.setShowPrintMargin(false);
+    editor.getSession().setUseWrapMode(true);
+
+    compiled.setTheme("ace/theme/twilight");
+    compiled.session.setMode("ace/mode/javascript");
+    compiled.session.setUseSoftTabs(true);
+    compiled.session.setTabSize(2);
+    compiled.setShowPrintMargin(false);
+    compiled.getSession().setUseWrapMode(true);
+}
+
+function resizePanels(sizes) {
+    setSizes(sizes);
+    // redraw in order for ace to pick up new sizes
+    updatePanels();
+}
 
 function compileIt(){
     chrome.devtools.inspectedWindow.eval( compiled.session.getValue(), function(result, isException) {});
@@ -30,6 +95,24 @@ function update(){
     }
     localStorage.setItem("state" + tabId, editor.session.getValue());
 }
+
+function movePanel(event) {
+  var offset = resultsPanel.offsetLeft;
+  // center resize cursor over gutter
+  var padding = gutter.offsetWidth / 2;
+  var to = event.pageX - padding;
+
+  var left = (to / window.innerWidth * 100).toFixed(2);
+  var right = (100 - (to / window.innerWidth * 100)).toFixed(2);
+
+    resizePanels({
+        editor: right + '%',
+        results: left + '%'
+    });
+}
+
+var sizes = getSizes();
+resizePanels(sizes);
 
 schedule = function(fn, timeout) {
     if (fn.$timer) return;
@@ -53,3 +136,10 @@ document.getElementById('runcc').addEventListener('click', compileIt);
 editor.session.setValue(localStorage.getItem("state" + tabId));
 schedule(function(){ editor.focus() }, 20);
 
+gutter.addEventListener('mousedown', function(event) {
+  window.addEventListener('mousemove', movePanel);
+});
+
+window.addEventListener('mouseup', function(event) {
+    window.removeEventListener('mousemove', movePanel);
+});

--- a/src/coffee-console-app.js
+++ b/src/coffee-console-app.js
@@ -1,0 +1,55 @@
+var tabId = chrome.devtools.inspectedWindow.tabId;
+var err = document.getElementById('error');
+var editor = ace.edit("cc-editor");
+editor.setTheme("ace/theme/twilight");
+editor.session.setMode("ace/mode/coffee");
+editor.session.setUseSoftTabs(true);
+editor.session.setTabSize(2);
+editor.setShowPrintMargin(false);
+
+var compiled = ace.edit("cc-results");
+compiled.setTheme("ace/theme/twilight");
+compiled.session.setMode("ace/mode/javascript");
+compiled.session.setUseSoftTabs(true);
+compiled.session.setTabSize(2);
+compiled.setShowPrintMargin(false);
+
+
+function compileIt(){
+    chrome.devtools.inspectedWindow.eval( compiled.session.getValue(), function(result, isException) {});
+}
+
+function update(){
+    try {
+        var compiledSource = CoffeeScript.compile( editor.session.getValue(), {bare:true});
+        compiled.session.setValue(compiledSource);
+        err.className = 'is-hidden';
+    } catch (error) {
+        err.className = '';
+        err.innerHTML = error.message;
+    }
+    localStorage.setItem("state" + tabId, editor.session.getValue());
+}
+
+schedule = function(fn, timeout) {
+    if (fn.$timer) return;
+    fn.$timer = setTimeout(function() {fn.$timer = null; fn()}, timeout || 10);
+}
+
+editor.on("change", function(e){
+    schedule(update, 20);
+});
+
+var compileOptions = {
+    name: "compileIt",
+    exec: compileIt,
+    bindKey: "Ctrl-Return|Command-Return|Shift-Return"
+};
+
+editor.commands.addCommand(compileOptions);
+compiled.commands.addCommand(compileOptions);
+
+document.getElementById('runcc').addEventListener('click', compileIt);
+editor.session.setValue(localStorage.getItem("state" + tabId));
+schedule(function(){ editor.focus() }, 20);
+

--- a/src/coffee-console.html
+++ b/src/coffee-console.html
@@ -45,10 +45,15 @@
             z-index: 2;
             opacity: .8;
             -webkit-transition: opacity .2s linear;
+            -webkit-transform: translate3d(0,0,0);
         }
 
         #error.is-hidden {
             opacity: 0;
+        }
+
+        #cc-results .ace_gutter {
+            cursor: ew-resize;
         }
     </style>
 </head>

--- a/src/coffee-console.html
+++ b/src/coffee-console.html
@@ -62,63 +62,7 @@
 <script src="ace/mode-coffee-noconflict.js" type="text/javascript" charset="utf-8"></script>
 <script src="ace/mode-javascript-noconflict.js" type="text/javascript" charset="utf-8"></script>
 <script src="ace/theme-twilight-noconflict.js" type="text/javascript" charset="utf-8"></script>
-<script>
-var tabId = chrome.devtools.inspectedWindow.tabId;
-var err = document.getElementById('error');
-var editor = ace.edit("cc-editor");
-editor.setTheme("ace/theme/twilight");
-editor.session.setMode("ace/mode/coffee");
-editor.session.setUseSoftTabs(true);
-editor.session.setTabSize(2);
-editor.setShowPrintMargin(false);
-
-var compiled = ace.edit("cc-results");
-compiled.setTheme("ace/theme/twilight");
-compiled.session.setMode("ace/mode/javascript");
-compiled.session.setUseSoftTabs(true);
-compiled.session.setTabSize(2);
-compiled.setShowPrintMargin(false);
-
-
-function compileIt(){
-    chrome.devtools.inspectedWindow.eval( compiled.session.getValue(), function(result, isException) {});
-}
-
-function update(){
-    try {
-        var compiledSource = CoffeeScript.compile( editor.session.getValue(), {bare:true});
-        compiled.session.setValue(compiledSource);
-        err.className = 'is-hidden';
-    } catch (error) {
-        err.className = '';
-        err.innerHTML = error.message;
-    }
-    localStorage.setItem("state" + tabId, editor.session.getValue());
-}
-
-schedule = function(fn, timeout) {
-    if (fn.$timer) return;
-    fn.$timer = setTimeout(function() {fn.$timer = null; fn()}, timeout || 10);
-}
-
-editor.on("change", function(e){
-    schedule(update, 20);
-});
-
-var compileOptions = {
-    name: "compileIt",
-    exec: compileIt,
-    bindKey: "Ctrl-Return|Command-Return|Shift-Return"
-};
-
-editor.commands.addCommand(compileOptions);
-compiled.commands.addCommand(compileOptions);
-
-document.getElementById('runcc').addEventListener('click', compileIt);
-editor.session.setValue(localStorage.getItem("state" + tabId));
-schedule(function(){ editor.focus() }, 20);
-
-</script>
+<script src="coffee-console-app.js"> </script>
 
 </body>
 </html>

--- a/src/coffee-console.js
+++ b/src/coffee-console.js
@@ -1,0 +1,9 @@
+chrome.devtools.panels.create(
+  "CoffeeConsole",
+  "badge.png",
+  "coffee-console.html",
+  function cb(panel) {
+    panel.onShown.addListener(function(win){ win.focus(); });
+  }
+);
+

--- a/src/coffee.html
+++ b/src/coffee.html
@@ -3,16 +3,7 @@
         <title>launcher</title>
     </head>
     <body>
-        <script>
-            chrome.devtools.panels.create(
-                "CoffeeConsole",
-                "badge.png",
-                "coffee-console.html",
-                function cb(panel) {
-                    panel.onShown.addListener(function(win){ win.focus(); });
-                }
-            );
-        </script>
+      <script src="coffee-console.js"></script>
     </body>
 </html>
 


### PR DESCRIPTION
This adds the ability to resize the editors by dragging on the middle gutter.

It also fixes an issue where the error transition causes the screen to flicker and sets the lines to wrap. 
